### PR TITLE
Parsing fixes

### DIFF
--- a/src/kimmdy/parsing.py
+++ b/src/kimmdy/parsing.py
@@ -4,10 +4,11 @@ from typing import Generator
 
 Topology = dict[str, list[list[str]]]
 
+
 def get_sections(
     seq: Iterable[str], section_marker: str
 ) -> Generator[list[str], None, None]:
-    data = ['']
+    data = [""]
     for line in seq:
         if line.startswith(section_marker):
             if data:


### PR DESCRIPTION
Blank lines are now used as section markers in order to not misattribute blocks without a `[ header ]` to the previous section. In the parsed dictionary those blocks can be accessed by `top["; BLOCK <number>"]`. Further, comments, prefixed by `;`, are now not thrown out. This ensures a lossless encoding. The onfly information now lost is whitespace, because every line will be parsed as a space separated list and put together when writing with one space in between each item, so  multiple consecutive spaces in the input will collapse into one space in the output. Because comments are now kept this potentially changes the way you have to modify the topology, e.g. changing a bond. Before merging I have to investigate how this influences the topology changer for the cleavage reaction.

@KRiedmiller @ehhartmann What are your thoughts on including comments? By definition they shouldn't contain information for gromacs, by they make reading the topology easier for humans and thus the resulting files more transferable. Do we want / need this?