### PR TITLE
Add function for concatenating produced trr files

### DIFF
--- a/src/kimmdy/misc_helper.py
+++ b/src/kimmdy/misc_helper.py
@@ -1,8 +1,9 @@
 from pathlib import Path
 import subprocess
+from typing import Union
 
 
-def concat_traj(run_dir: Path, out: Path, run_types=None):
+def concat_traj(run_dir: Union[Path, str], out: Union[Path, str], run_types=None):
     """Find and concatenate trajectories from KIMMDY runs.
 
     Parameters
@@ -11,10 +12,15 @@ def concat_traj(run_dir: Path, out: Path, run_types=None):
         Directory containing directories of multiple tasks.
     out : Path
         File Path into the output trr will be written.
+        Can be relative to run_dir
     run_types : list, optional
         List of tasks to get trrs from. If a task is not in this list
         it will be skipped. By default None
     """
+    run_dir = Path(run_dir).expanduser().resolve()
+    out = Path(out).expanduser()
+    assert out.suffix == ".trr", "Output file should be a trr file."
+
     dirs = sorted(
         list(filter(lambda d: d.is_dir(), run_dir.iterdir())),
         key=lambda p: int(p.name.split("_")[0]),
@@ -28,7 +34,6 @@ def concat_traj(run_dir: Path, out: Path, run_types=None):
         trrs.extend(d.glob("*.trr"))
     trrs = [str(t) for t in trrs]
 
-    assert out.suffix == ".trr", "Output file should be a trr file."
     command = f"gmx trjcat -f {' '.join(trrs)} -o {str(out)} -cat".split(" ")
 
     subprocess.run(command, cwd=run_dir)


### PR DESCRIPTION
Helper function going through kimmdy output, concatenating all (or only production) trrs.

As we create the file structure, I feel including this is justifyed.