### PR TITLE
feat: default options for config

### DIFF
--- a/src/kimmdy/config.py
+++ b/src/kimmdy/config.py
@@ -44,6 +44,7 @@ type_scheme = {
     "out": Path,
     "gromacs_alias": str,
     "ff": Path,
+    "gmx_mdrun_flags": str,
     "ffpatch": None,
     "top": Path,
     "gro": Path,
@@ -116,6 +117,7 @@ class Config:
     out: Path
     gromacs_alias: str
     ff: Path
+    gmx_mdrun_flags: str
     ffpatch: Optional[Path]
     top: Path
     gro: Path


### PR DESCRIPTION
Initially I just wanted to add a `gmx_mdrun_flags` option to the config to fix #145.

But then I reallized, that everyt time I have to modify the config I am confused. This has multiple reasons I'll attempt to fix in this PR:
a) no straightforward way to specify defaults for (optional) configs
b) metaprogramming that is too clever for me (such as dynamically setting and modifying class attributes
c) a mix of programming styles

In combination, b and c lead to the config object potentially lying to us in the codebase. Because specifying types for the attributes only leads to a false sense of security when they are being set dynamically and in a different place in the code that is completely disjunct from the types specified.
 
This time I want to avoid additional frameworks though, so I'm rather going back to being more basic and pythonic and maybe less clever.