### PR TITLE
fix: inconsistent inheritance

### DIFF
--- a/src/kimmdy/reaction.py
+++ b/src/kimmdy/reaction.py
@@ -172,7 +172,7 @@ class SingleOperation(RecipeStep):
         self._atom_ix_2 = value
 
 
-class Break(SingleOperation, RecipeStep):
+class Break(SingleOperation):
     """Change topology to break a bond
 
     Attributes


### PR DESCRIPTION
Break and Bind should probably both just be `SingleOperation`s  
@jmbuhr I'm not overlooking something?