### PR TITLE
fix: consistent use of `edis` in homolysis config

### DIFF
--- a/example/example_hexala/kimmdy.yml
+++ b/example/example_hexala/kimmdy.yml
@@ -23,7 +23,7 @@ changer:
 reactions:
   homolysis:
     edis: 'edissoc.dat'
-    bonds: 'ffbonded.itp'
+    itp: 'ffbonded.itp'
   # HAT_dummy:
 sequence:
   - equilibrium

--- a/example/example_short/kimmdy.yml
+++ b/example/example_short/kimmdy.yml
@@ -22,7 +22,7 @@ changer:
 reactions:
   homolysis:
     edis: 'edissoc.dat'
-    bonds: 'ffbonded.itp'
+    itp: 'ffbonded.itp'
   dummyreaction: {}
 sequence:
   - equilibrium

--- a/plugins/src/homolysis/kimmdy-yaml-schema.json
+++ b/plugins/src/homolysis/kimmdy-yaml-schema.json
@@ -5,7 +5,7 @@
   "description": "Settings for homolysis reactions",
   "additionalProperties": false,
   "properties": {
-    "dat": {
+    "edis": {
       "type": "string",
       "pytype": "Path",
       "description": "Dissociation energies ata file",
@@ -18,6 +18,6 @@
       "default": "ffbonded.itp"
     }
   },
-  "required": [ "dat", "itp" ]
+  "required": [ "edis", "itp" ]
 }
 

--- a/plugins/src/homolysis/reaction.py
+++ b/plugins/src/homolysis/reaction.py
@@ -33,7 +33,7 @@ class Homolysis(ReactionPlugin):
         distances_dat = files.input["distances.dat"]
         topol_top = files.input["top"]
         ffbonded_itp = self.config.itp
-        edissoc_dat = self.config.dat
+        edissoc_dat = self.config.edis
 
         # Initialization of objects from files
         distances = read_distances_dat(distances_dat)


### PR DESCRIPTION
closes #169