### PR TITLE
fix: removed need for strict bind break order

### DIFF
--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -688,9 +688,9 @@ class Topology:
         logging.info(f"removed bond: {removed_bond}")
 
         # remove angles
-        angle_keys = moleculetype._get_atom_angles(
+        angle_keys = moleculetype._get_center_atom_angles(
             atompair_nrs[0]
-        ) + moleculetype._get_atom_angles(atompair_nrs[1])
+        ) + moleculetype._get_center_atom_angles(atompair_nrs[1])
         for key in angle_keys:
             if all([x in key for x in atompair_nrs]):
                 # angle contained a now deleted bond because


### PR DESCRIPTION
break_bond will only break angles which have either bond atom as a center atom. This way it does not break too many angles in the case of a 3-ring system (from using bind before break for neighboring heavy atoms)