### PR TITLE
Fix morse transition rate

### DIFF
--- a/src/kimmdy/utils.py
+++ b/src/kimmdy/utils.py
@@ -217,7 +217,7 @@ def morse_transition_rate(
                     beta**2 * dissociation_energy**2
                     - 2 * dissociation_energy * beta * fs
                 )
-                + 1e-7 # prevent rounding issue close to zero
+                + 1e-7  # prevent rounding issue close to zero
             )
         )
         / (2 * beta * dissociation_energy)
@@ -230,7 +230,7 @@ def morse_transition_rate(
                     beta**2 * dissociation_energy**2
                     - 2 * dissociation_energy * beta * fs
                 )
-                + 1e-7 # prevent rounding issue close to zero
+                + 1e-7  # prevent rounding issue close to zero
             )
         )
         / (2 * beta * dissociation_energy)


### PR DESCRIPTION
Clean pull request to fix #197 #201 #205

> Proposed fix: add 1e-7 in the sqrt
> 
> local: No difference
> 
> ```python
> >>> r_0 - 1 / beta * np.log(
> ...         (
> ...             beta * dissociation_energy
> ...             + np.sqrt(
> ...                 (
> ...                     beta**2 * dissociation_energy**2
> ...                     - 2 * dissociation_energy * beta * fs
> ...                 )
> ...                 + 1e-7  # circumvent rounding issues close to zero
> ...             )
> ...         )
> ...         / (2 * beta * dissociation_energy)
> ...     )
> array([0.13698   , 0.14567714, 0.15437429, 0.16307143, 0.17176857,
>        0.18046571, 0.18770501, 0.18770501])
> >>> r_0 - 1 / beta * np.log(
> ...         (
> ...             beta * dissociation_energy
> ...             + np.sqrt(
> ...                 (
> ...                     beta**2 * dissociation_energy**2
> ...                     - 2 * dissociation_energy * beta * fs
> ...                 )
> ...                 # + 1e-7  # circumvent rounding issues close to zero
> ...             )
> ...         )
> ...         / (2 * beta * dissociation_energy)
> ...     )
> array([0.13698   , 0.14567714, 0.15437429, 0.16307143, 0.17176857,
>        0.18046571, 0.18770501, 0.18770501])
> ```
> 
> cluster:
> 
> ```python
> >>> r_0 - 1 / beta * np.log(
> ...         (
> ...             beta * dissociation_energy
> ...             + np.sqrt(
> ...                 (
> ...                     beta**2 * dissociation_energy**2
> ...                     - 2 * dissociation_energy * beta * fs
> ...                 )
> ...                 + 1e-7  # circumvent rounding issues close to zero
> ...             )
> ...         )
> ...         / (2 * beta * dissociation_energy)
> ...     )
> array([0.13698   , 0.14567714, 0.15437429, 0.16307143, 0.17176857,
>        0.18046571, 0.18770501, 0.18770501])
> >>> r_0 - 1 / beta * np.log(
> ...         (
> ...             beta * dissociation_energy
> ...             + np.sqrt(
> ...                 (
> ...                     beta**2 * dissociation_energy**2
> ...                     - 2 * dissociation_energy * beta * fs
> ...                 )
> ...                 # + 1e-7  # circumvent rounding issues close to zero
> ...             )
> ...         )
> ...         / (2 * beta * dissociation_energy)
> ...     )
> array([0.13698   , 0.14567714, 0.15437429, 0.16307143, 0.17176857,
>        0.18046571,        nan,        nan])
> ```

