### PR TITLE
lambda dynamics relaxation after homolysis

### DIFF
--- a/plugins/default_reactions/src/homolysis/reaction.py
+++ b/plugins/default_reactions/src/homolysis/reaction.py
@@ -63,7 +63,10 @@ class Homolysis(ReactionPlugin):
 
             recipes.append(
                 Recipe(
-                    recipe_steps=[Break(atom_id_1=atomids[0], atom_id_2=atomids[1]), Relax()],
+                    recipe_steps=[
+                        Break(atom_id_1=atomids[0], atom_id_2=atomids[1]),
+                        Relax(),
+                    ],
                     rates=[*k_avg],
                     timespans=[(distances["time"][0], distances["time"][-1])],
                 )


### PR DESCRIPTION
I think we want and had a relax md after a homolysis event, however, currently it is not performed as this md step has become its own `RecipeStep`.

This PR adds back the relax md step.  
Or was this missing on purpose? @jmbuhr @ehhartmann