### PR TITLE
feat: recipes with deferred RecipeSteps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,12 +7,6 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
-  fail-if-pull-request-is-draft:
-    if: github.event.pull_request.draft == true
-    runs-on: ubuntu-latest
-    steps:
-    - name: Fails in order to indicate that pull request needs to be marked as ready to review and unit tests workflow needs to pass.
-      run: exit 1
   test:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest

--- a/src/kimmdy/analysis.py
+++ b/src/kimmdy/analysis.py
@@ -471,7 +471,7 @@ def reaction_participation(dir: str, open_plot: bool = False):
             continue
         # get involved atoms
         reaction_atom_ids = set()
-        for step in picked_rp.recipe_steps:
+        for step in picked_rp.steps:
             if isinstance(step, Break) or isinstance(step, Bind):
                 reaction_atom_ids |= set([step.atom_id_1, step.atom_id_2])
             elif isinstance(step, Place):

--- a/src/kimmdy/analysis.py
+++ b/src/kimmdy/analysis.py
@@ -471,7 +471,7 @@ def reaction_participation(dir: str, open_plot: bool = False):
             continue
         # get involved atoms
         reaction_atom_ids = set()
-        for step in picked_rp.steps:
+        for step in picked_rp.recipe_steps:
             if isinstance(step, Break) or isinstance(step, Bind):
                 reaction_atom_ids |= set([step.atom_id_1, step.atom_id_2])
             elif isinstance(step, Place):

--- a/src/kimmdy/assets/templates.py
+++ b/src/kimmdy/assets/templates.py
@@ -40,7 +40,7 @@ if [ $HOURS -lt $CYCLE ]; then
   exit 3
 else
   echo "jobscript resubmitting"
-  sed -i.bak "s/\(run_directory:\s*\).*/\\1'{config.out.name}'/" {config.input_file}
+  sed -i.bak "s/\\(run_directory:\\s*\\).*/\\1'{config.out.name}'/" {config.input_file}
   kimmdy --generate-jobscript
   sbatch ./jobscript.sh
   exit 2

--- a/src/kimmdy/cmd.py
+++ b/src/kimmdy/cmd.py
@@ -6,7 +6,6 @@ Other entry points such as `kimmdy-analysis` also live here.
 import argparse
 import logging
 import logging.config
-import os
 import shutil
 import sys
 import textwrap

--- a/src/kimmdy/cmd.py
+++ b/src/kimmdy/cmd.py
@@ -103,7 +103,6 @@ def _run(args: argparse.Namespace):
     args
         Command line arguments. See [](`~kimmdy.cmd.get_cmdline_args`)
     """
-
     if args.show_plugins:
         discover_plugins()
 
@@ -145,7 +144,7 @@ def _run(args: argparse.Namespace):
         # from initial config parsing
         # before the logger was configured
         # (because the logger config depends on the config)
-        for info in config._logmessages["debug"]:
+        for info in config._logmessages["debugs"]:
             logger.debug(info)
         for info in config._logmessages["infos"]:
             logger.info(info)

--- a/src/kimmdy/config.py
+++ b/src/kimmdy/config.py
@@ -202,7 +202,12 @@ class Config:
             # NOTE: The logger is set up with information from the config
             # the the config can't use the logger.
             # Instead it collects the logmessages and displays them at the end.
-            self._logmessages = {"infos": [], "warnings": [], "errors": [], "debugs": []}
+            self._logmessages = {
+                "infos": [],
+                "warnings": [],
+                "errors": [],
+                "debugs": [],
+            }
             self._set_defaults(section, scheme)
             self._validate(section=section, cwd=self.cwd)
 

--- a/src/kimmdy/config.py
+++ b/src/kimmdy/config.py
@@ -199,7 +199,10 @@ class Config:
 
         # validate on initial construction
         if section == "config":
-            self._logmessages = {"infos": [], "warnings": [], "errors": [], "debug": []}
+            # NOTE: The logger is set up with information from the config
+            # the the config can't use the logger.
+            # Instead it collects the logmessages and displays them at the end.
+            self._logmessages = {"infos": [], "warnings": [], "errors": [], "debugs": []}
             self._set_defaults(section, scheme)
             self._validate(section=section, cwd=self.cwd)
 
@@ -297,7 +300,7 @@ class Config:
 
             # make sure self.out is empty
             while self.out.exists():
-                self._logmessages["debug"].append(
+                self._logmessages["debugs"].append(
                     f"Output dir {self.out} exists, incrementing name"
                 )
                 name = self.out.name.split("_")
@@ -417,7 +420,8 @@ class Config:
                         raise AssertionError(
                             "Plumed requested in md section, but not defined at config root"
                         )
-                    check_gmx_version(self)
+
+                check_gmx_version(self)
 
         # individual attributes, recursively
         for name, attr in self.__dict__.items():

--- a/src/kimmdy/coordinates.py
+++ b/src/kimmdy/coordinates.py
@@ -505,7 +505,7 @@ def merge_top_moleculetypes_slow_growth(
                         neighbor_set.add(b[0])
                         neighbor_set.add(b[1])
                     neighbor_sides.append(neighbor_set)
-                neighbor_set.discard(idx)  # avoid double counting central bond
+                neighbor_set.discard(idx) # type: ignore  # avoid double counting central bond
 
                 # handle growing exclusions neighbors1 - key[1]
                 for a1 in neighbor_sides[0]:
@@ -701,8 +701,9 @@ def merge_top_slow_growth(
 
     molA = topA.moleculetypes[REACTIVE_MOLECULEYPE]
     molB = topB.moleculetypes[REACTIVE_MOLECULEYPE]
-    molB = merge_top_moleculetypes_slow_growth(molA, molB, topB.ff, morph_pairs)
-    topB._update_dict()
+    molB = merge_top_moleculetypes_slow_growth(molA=molA, molB=molB, ff=topB.ff, morph_pairs=morph_pairs)
+    # not necessary, will be updated automatically on `to_dict()`
+    # topB._update_dict()
 
     return topB
 

--- a/src/kimmdy/coordinates.py
+++ b/src/kimmdy/coordinates.py
@@ -505,7 +505,7 @@ def merge_top_moleculetypes_slow_growth(
                         neighbor_set.add(b[0])
                         neighbor_set.add(b[1])
                     neighbor_sides.append(neighbor_set)
-                neighbor_set.discard(idx) # type: ignore  # avoid double counting central bond
+                neighbor_set.discard(idx)  # type: ignore  # avoid double counting central bond
 
                 # handle growing exclusions neighbors1 - key[1]
                 for a1 in neighbor_sides[0]:
@@ -701,7 +701,9 @@ def merge_top_slow_growth(
 
     molA = topA.moleculetypes[REACTIVE_MOLECULEYPE]
     molB = topB.moleculetypes[REACTIVE_MOLECULEYPE]
-    molB = merge_top_moleculetypes_slow_growth(molA=molA, molB=molB, ff=topB.ff, morph_pairs=morph_pairs)
+    molB = merge_top_moleculetypes_slow_growth(
+        molA=molA, molB=molB, ff=topB.ff, morph_pairs=morph_pairs
+    )
     # not necessary, will be updated automatically on `to_dict()`
     # topB._update_dict()
 

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -120,7 +120,9 @@ def rf_kmc(
 
     # 5. Calculate the time step associated with mu
     time_delta = np.log(1 / u[1]) / probability_sum
-    logger.info(f"Time delta: {time_delta}\nwith cumulative probability {probability_sum}")
+    logger.info(
+        f"Time delta: {time_delta}\nwith cumulative probability {probability_sum}"
+    )
 
     return KMCResult(
         recipe=recipe,

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -120,7 +120,7 @@ def rf_kmc(
 
     # 5. Calculate the time step associated with mu
     time_delta = np.log(1 / u[1]) / probability_sum
-    logger.info(f"Time delta: {time_delta}\nprobability {reaction_probability}")
+    logger.info(f"Time delta: {time_delta}\nwith cumulative probability {probability_sum}")
 
     return KMCResult(
         recipe=recipe,

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -11,7 +11,7 @@ and because we have one reactant molecule
 import logging
 from dataclasses import dataclass, field
 from itertools import pairwise
-from typing import Optional
+from typing import Callable, Optional
 
 import numpy as np
 from numpy.random import default_rng
@@ -34,12 +34,15 @@ class KMCResult:
     time_start
         Time, from which the reaction starts. The reaction changes the
         geometry/topology of this timestep and continues from there. [ps]
+    pos
+        Position (index) of the chosen recipe in the RecipeCollection
     """
 
-    recipe: Recipe = field(default_factory=lambda: Recipe([], [], []))
+    recipe: Recipe|Callable[[int], Recipe] = field(default_factory=lambda: Recipe([], [], []))
     reaction_probability: Optional[list[float]] = None
     time_delta: Optional[float] = None
     time_start: Optional[float] = None
+    pos: Optional[int] = None
 
 
 def rf_kmc(
@@ -102,6 +105,7 @@ def rf_kmc(
         reaction_probability=reaction_probability,
         time_delta=time_delta,
         time_start=reaction_time,
+        pos=pos
     )
 
 
@@ -176,6 +180,7 @@ def frm(
         reaction_probability=reaction_probability,
         time_delta=time_delta,
         time_start=reaction_time,
+        pos=int(pos_event)
     )
 
 
@@ -295,6 +300,7 @@ def extrande_mod(
         reaction_probability=None,
         time_delta=0,  # instantaneous reaction
         time_start=t,
+        pos=int(idx_rate_max)
     )
 
 
@@ -427,4 +433,5 @@ def extrande(
         reaction_probability=None,
         time_delta=0,  # instantaneous reaction
         time_start=t,
+        pos=int(idx_rate_max)
     )

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -34,15 +34,12 @@ class KMCResult:
     time_start
         Time, from which the reaction starts. The reaction changes the
         geometry/topology of this timestep and continues from there. [ps]
-    pos
-        Position (index) of the chosen recipe in the RecipeCollection
     """
 
-    recipe: Recipe|Callable[[int], Recipe] = field(default_factory=lambda: Recipe([], [], []))
+    recipe: Recipe = field(default_factory=lambda: Recipe([], [], []))
     reaction_probability: Optional[list[float]] = None
     time_delta: Optional[float] = None
     time_start: Optional[float] = None
-    pos: Optional[int] = None
 
 
 def rf_kmc(
@@ -105,7 +102,6 @@ def rf_kmc(
         reaction_probability=reaction_probability,
         time_delta=time_delta,
         time_start=reaction_time,
-        pos=pos
     )
 
 
@@ -180,7 +176,6 @@ def frm(
         reaction_probability=reaction_probability,
         time_delta=time_delta,
         time_start=reaction_time,
-        pos=int(pos_event)
     )
 
 
@@ -300,7 +295,6 @@ def extrande_mod(
         reaction_probability=None,
         time_delta=0,  # instantaneous reaction
         time_start=t,
-        pos=int(idx_rate_max)
     )
 
 
@@ -433,5 +427,4 @@ def extrande(
         reaction_probability=None,
         time_delta=0,  # instantaneous reaction
         time_start=t,
-        pos=int(idx_rate_max)
     )

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -22,7 +22,9 @@ from kimmdy.recipe import Recipe, RecipeCollection
 logger = logging.getLogger(__name__)
 
 
-def total_index_to_index_within_plugin(total_index: int, n_recipes_per_plugin: list[int]) -> int:
+def total_index_to_index_within_plugin(
+    total_index: int, n_recipes_per_plugin: list[int]
+) -> int:
     i = total_index
     for n in [0] + n_recipes_per_plugin:
         if i - n < 0:
@@ -52,20 +54,22 @@ class KMCResult:
     """
 
     recipe: Recipe
-    reaction_probability: list[float]|None
+    reaction_probability: list[float] | None
     time_delta: float
     time_start: float
     time_start_index: int
-    time_start_index_within_plugin: int|None = None
+    time_start_index_within_plugin: int | None = None
+
 
 @dataclass
 class KMCRejection:
-    reason: str|None = None
+    reason: str | None = None
+
 
 def rf_kmc(
     recipe_collection: RecipeCollection,
     rng: np.random.Generator = default_rng(),
-) -> KMCResult|KMCRejection:
+) -> KMCResult | KMCRejection:
     """Rejection-Free Monte Carlo.
     Takes RecipeCollection and choses a recipe based on the relative propensity of the events.
     The 'start' time of the reaction is the time of the highest rate of the accepted reaction.
@@ -131,7 +135,7 @@ def frm(
     recipe_collection: RecipeCollection,
     rng: np.random.Generator = default_rng(),
     MD_time: Optional[float] = None,
-) -> KMCResult|KMCRejection:
+) -> KMCResult | KMCRejection:
     """First Reaction Method variant of Kinetic Monte Carlo.
     takes RecipeCollection and choses a recipe based on which reaction would occur.
 
@@ -191,9 +195,7 @@ def frm(
         reaction_time = chosen_recipe.timespans[time_index][1]
     except ValueError:
         m = f"FRM recipe selection did not work, probably tau: {tau} is empty."
-        logger.warning(
-            m
-        )
+        logger.warning(m)
         return KMCRejection(m)
 
     return KMCResult(
@@ -201,7 +203,7 @@ def frm(
         reaction_probability=reaction_probability,
         time_delta=time_delta,
         time_start=reaction_time,
-        time_start_index=int(time_index)
+        time_start_index=int(time_index),
     )
 
 
@@ -209,7 +211,7 @@ def extrande_mod(
     recipe_collection: RecipeCollection,
     tau_scale: float,
     rng: np.random.Generator = default_rng(),
-) -> KMCResult|KMCRejection:
+) -> KMCResult | KMCRejection:
     """Modified Extrande KMC
 
     Improved implementation of
@@ -320,7 +322,7 @@ def extrande_mod(
         reaction_probability=None,
         time_delta=0,  # instantaneous reaction
         time_start=t,
-        time_start_index=int(idx_rate_max)
+        time_start_index=int(idx_rate_max),
     )
 
 
@@ -328,7 +330,7 @@ def extrande(
     recipe_collection: RecipeCollection,
     tau_scale: float,
     rng: np.random.Generator = default_rng(),
-) -> KMCResult|KMCRejection:
+) -> KMCResult | KMCRejection:
     """Extrande KMC
 
     Implemented as in
@@ -450,5 +452,5 @@ def extrande(
         reaction_probability=None,
         time_delta=0,  # instantaneous reaction
         time_start=t,
-        time_start_index=int(idx_rate_max)
+        time_start_index=int(idx_rate_max),
     )

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -15,8 +15,21 @@ from typing import Optional
 
 import numpy as np
 from numpy.random import default_rng
+import logging
 
 from kimmdy.recipe import Recipe, RecipeCollection
+
+logger = logging.getLogger(__name__)
+
+
+def total_index_to_index_within_plugin(total_index: int, n_recipes_per_plugin: list[int]) -> int:
+    i = total_index
+    for n in [0] + n_recipes_per_plugin:
+        if i - n < 0:
+            return i
+        else:
+            i -= n
+    return i
 
 
 @dataclass
@@ -50,7 +63,6 @@ class KMCRejection:
 
 def rf_kmc(
     recipe_collection: RecipeCollection,
-    logger: logging.Logger = logging.getLogger(__name__),
     rng: np.random.Generator = default_rng(),
 ) -> KMCResult|KMCRejection:
     """Rejection-Free Monte Carlo.
@@ -116,7 +128,6 @@ def rf_kmc(
 
 def frm(
     recipe_collection: RecipeCollection,
-    logger: logging.Logger = logging.getLogger(__name__),
     rng: np.random.Generator = default_rng(),
     MD_time: Optional[float] = None,
 ) -> KMCResult|KMCRejection:
@@ -196,7 +207,6 @@ def frm(
 def extrande_mod(
     recipe_collection: RecipeCollection,
     tau_scale: float,
-    logger: logging.Logger = logging.getLogger(__name__),
     rng: np.random.Generator = default_rng(),
 ) -> KMCResult|KMCRejection:
     """Modified Extrande KMC
@@ -316,7 +326,6 @@ def extrande_mod(
 def extrande(
     recipe_collection: RecipeCollection,
     tau_scale: float,
-    logger: logging.Logger = logging.getLogger(__name__),
     rng: np.random.Generator = default_rng(),
 ) -> KMCResult|KMCRejection:
     """Extrande KMC

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -56,6 +56,7 @@ class KMCResult:
     time_delta: float
     time_start: float
     time_start_index: int
+    time_start_index_within_plugin: int|None = None
 
 @dataclass
 class KMCRejection:

--- a/src/kimmdy/kmc.py
+++ b/src/kimmdy/kmc.py
@@ -8,11 +8,10 @@ because of the fundamental premise of chemical kinetics
 and because we have one reactant molecule
 """
 
-import enum
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from itertools import pairwise
-from typing import Callable, Optional
+from typing import Optional
 
 import numpy as np
 from numpy.random import default_rng

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -24,7 +24,7 @@ def recipe_steps_from_str(
     recipe_steps_s: str,
 ) -> list[RecipeStep] | DeferredRecipeSteps:
     if recipe_steps_s.startswith("<") and recipe_steps_s.endswith(">"):
-        key,callback = recipe_steps_s.removeprefix("<").removesuffix(">").split(",")
+        key, callback = recipe_steps_s.removeprefix("<").removesuffix(">").split(",")
 
         def dummy_callback(key, i):
             _ = key
@@ -532,8 +532,6 @@ class Recipe:
                 ixs.add(rs.atom_ix_1)
                 ixs.add(rs.atom_ix_2)
         return "index " + " ".join([str(ix) for ix in ixs])
-
-
 
     def combine_with(self, other: Recipe):
         """Combines this Recipe with another with the same RecipeSteps.

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -560,13 +560,13 @@ class Recipe:
                 raise ValueError(f"rates must be a list, not {type(self.rates)}")
 
         except ValueError as e:
-            raise ValueError(f"Consistency error in Recipe {self.recipe_steps}\n" + e.args[0])
+            raise ValueError(
+                f"Consistency error in Recipe {self.recipe_steps}\n" + e.args[0]
+            )
 
     def get_recipe_name(self):
         if isinstance(self.recipe_steps, DeferredRecipeSteps):
-            return (
-                f"DeferredRecipeSteps({self.recipe_steps.key}, {self.recipe_steps.callback.__name__})"
-            )
+            return f"DeferredRecipeSteps({self.recipe_steps.key}, {self.recipe_steps.callback.__name__})"
         name = ""
         for rs in self.recipe_steps:
             name += " "
@@ -644,7 +644,8 @@ class Recipe:
         ):
             if (
                 self.recipe_steps.key == other.recipe_steps.key
-                and self.recipe_steps.callback.__name__ == other.recipe_steps.callback.__name__
+                and self.recipe_steps.callback.__name__
+                == other.recipe_steps.callback.__name__
             ):
                 return True
 
@@ -661,6 +662,7 @@ class RecipeCollection:
     recipes
         List of Recipe objects.
     """
+
     recipes: list[Recipe]
 
     def aggregate_reactions(self):
@@ -739,7 +741,9 @@ class RecipeCollection:
                 timespans = ast.literal_eval(timespans_s)
                 rates = ast.literal_eval(rates_s)
 
-                recipe = Recipe(recipe_steps=recipe_steps, timespans=timespans, rates=rates)
+                recipe = Recipe(
+                    recipe_steps=recipe_steps, timespans=timespans, rates=rates
+                )
                 recipes.append(recipe)
                 if picked:
                     picked_rp = recipe

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -20,19 +20,23 @@ if TYPE_CHECKING:
     from kimmdy.topology.topology import Topology
 
 
-def recipe_steps_from_str(recipe_steps_s: str) -> list[RecipeStep]|DeferredRecipeSteps:
+def recipe_steps_from_str(
+    recipe_steps_s: str,
+) -> list[RecipeStep] | DeferredRecipeSteps:
     if recipe_steps_s.startswith("<") and recipe_steps_s.endswith(">"):
         key, callback = recipe_steps_s.removeprefix("<").removesuffix(">").split(",")
+
         def dummy_callback(key):
             _ = key
             return []
+
         dummy_callback.__name__ = callback
         # NOTE: because this is parsed from a string, we don't have
         # the actual function, so we just return a dummy function
         # It can't actually be used to reconstruct the original closure
         # because we don't have access to the runtime state
         # of the ReactionPlugin that produced the closure
-        # Likewise, the type of the key is unknown and 
+        # Likewise, the type of the key is unknown and
         # will be a string, not the actual type over which
         # DeferredRecipeSteps is generic.
         return DeferredRecipeSteps(key=key, callback=dummy_callback)
@@ -453,7 +457,8 @@ class CustomTopMod(RecipeStep):
         return cls(f=f)
 
 
-T = TypeVar('T')
+T = TypeVar("T")
+
 
 @dataclass
 class DeferredRecipeSteps(Generic[T]):
@@ -463,7 +468,10 @@ class DeferredRecipeSteps(Generic[T]):
     def __eq__(self, other) -> bool:
         if not isinstance(other, DeferredRecipeSteps):
             return False
-        return self.key == other.key and self.callback.__name__ == other.callback.__name__
+        return (
+            self.key == other.key and self.callback.__name__ == other.callback.__name__
+        )
+
 
 @dataclass
 class Recipe:
@@ -491,7 +499,7 @@ class Recipe:
 
     """
 
-    steps: list[RecipeStep]|DeferredRecipeSteps
+    steps: list[RecipeStep] | DeferredRecipeSteps
     rates: list[float]
     timespans: list[tuple[float, float]]
 
@@ -540,7 +548,7 @@ class Recipe:
                     f"\trates: {len(self.rates)}\n"
                     f"\ttimespans: {len(self.timespans)}"
                 )
-            if not isinstance(self.steps, list|DeferredRecipeSteps):
+            if not isinstance(self.steps, list | DeferredRecipeSteps):
                 raise ValueError(
                     f"Recipe Steps must be a list (or tuple for deferred evaluation), not {type(self.steps)}"
                 )
@@ -552,13 +560,13 @@ class Recipe:
                 raise ValueError(f"rates must be a list, not {type(self.rates)}")
 
         except ValueError as e:
-            raise ValueError(
-                f"Consistency error in Recipe {self.steps}\n" + e.args[0]
-            )
+            raise ValueError(f"Consistency error in Recipe {self.steps}\n" + e.args[0])
 
     def get_recipe_name(self):
         if isinstance(self.steps, DeferredRecipeSteps):
-            return f"DeferredRecipeSteps({self.steps.key}, {self.steps.callback.__name__})"
+            return (
+                f"DeferredRecipeSteps({self.steps.key}, {self.steps.callback.__name__})"
+            )
         name = ""
         for rs in self.steps:
             name += " "
@@ -618,7 +626,9 @@ class Recipe:
         if type(self.steps) != type(other.steps):
             return False
 
-        if not isinstance(self.steps, DeferredRecipeSteps) and not isinstance(other.steps, DeferredRecipeSteps):
+        if not isinstance(self.steps, DeferredRecipeSteps) and not isinstance(
+            other.steps, DeferredRecipeSteps
+        ):
             if len(self.steps) != len(other.steps):
                 return False
             for rs1, rs2 in zip(self.steps, other.steps):
@@ -629,9 +639,14 @@ class Recipe:
                     if rs1 != rs2:
                         return False
 
-        if isinstance(self.steps, DeferredRecipeSteps) and isinstance(other.steps, DeferredRecipeSteps):
-            if self.steps.key == other.steps.key and self.steps.callback.__name__ == other.steps.callback.__name__:
-                return True 
+        if isinstance(self.steps, DeferredRecipeSteps) and isinstance(
+            other.steps, DeferredRecipeSteps
+        ):
+            if (
+                self.steps.key == other.steps.key
+                and self.steps.callback.__name__ == other.steps.callback.__name__
+            ):
+                return True
 
         return self.rates == other.rates and self.timespans == other.timespans
 
@@ -720,9 +735,7 @@ class RecipeCollection:
                 timespans = ast.literal_eval(timespans_s)
                 rates = ast.literal_eval(rates_s)
 
-                recipe = Recipe(
-                    steps=recipe_steps, timespans=timespans, rates=rates
-                )
+                recipe = Recipe(steps=recipe_steps, timespans=timespans, rates=rates)
                 recipes.append(recipe)
                 if picked:
                     picked_rp = recipe

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -518,6 +518,23 @@ class Recipe:
             timespans=list(self.timespans),
         )
 
+    def get_vmd_selection(self) -> str:
+        """Get a VMD selection string
+
+        for the atoms involved in the recipe steps.
+        """
+        if isinstance(self.recipe_steps, DeferredRecipeSteps):
+            return ""
+        ixs = set()
+        for rs in self.recipe_steps:
+            print(self.recipe_steps)
+            if isinstance(rs, BondOperation):
+                ixs.add(rs.atom_ix_1)
+                ixs.add(rs.atom_ix_2)
+        return "index" + " ".join([str(ix) for ix in ixs])
+
+
+
     def combine_with(self, other: Recipe):
         """Combines this Recipe with another with the same RecipeSteps.
 

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -463,7 +463,7 @@ T = TypeVar("T")
 @dataclass
 class DeferredRecipeSteps(Generic[T]):
     key: T
-    callback: Callable[[T], list[RecipeStep]]
+    callback: Callable[[T, int], list[RecipeStep]]
 
     def __eq__(self, other) -> bool:
         if not isinstance(other, DeferredRecipeSteps):

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -531,7 +531,7 @@ class Recipe:
             if isinstance(rs, BondOperation):
                 ixs.add(rs.atom_ix_1)
                 ixs.add(rs.atom_ix_2)
-        return "index" + " ".join([str(ix) for ix in ixs])
+        return "index " + " ".join([str(ix) for ix in ixs])
 
 
 

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -24,10 +24,11 @@ def recipe_steps_from_str(
     recipe_steps_s: str,
 ) -> list[RecipeStep] | DeferredRecipeSteps:
     if recipe_steps_s.startswith("<") and recipe_steps_s.endswith(">"):
-        key, callback = recipe_steps_s.removeprefix("<").removesuffix(">").split(",")
+        key,callback = recipe_steps_s.removeprefix("<").removesuffix(">").split(",")
 
-        def dummy_callback(key):
+        def dummy_callback(key, i):
             _ = key
+            _ = i
             return []
 
         dummy_callback.__name__ = callback
@@ -566,7 +567,7 @@ class Recipe:
 
     def get_recipe_name(self):
         if isinstance(self.recipe_steps, DeferredRecipeSteps):
-            return f"DeferredRecipeSteps({self.recipe_steps.key}, {self.recipe_steps.callback.__name__})"
+            return f"DeferredRecipeSteps({self.recipe_steps.key},{self.recipe_steps.frame_index}, {self.recipe_steps.callback.__name__})"
         name = ""
         for rs in self.recipe_steps:
             name += " "

--- a/src/kimmdy/recipe.py
+++ b/src/kimmdy/recipe.py
@@ -567,7 +567,7 @@ class Recipe:
 
     def get_recipe_name(self):
         if isinstance(self.recipe_steps, DeferredRecipeSteps):
-            return f"DeferredRecipeSteps({self.recipe_steps.key},{self.recipe_steps.frame_index}, {self.recipe_steps.callback.__name__})"
+            return f"DeferredRecipeSteps({self.recipe_steps.key}, {self.recipe_steps.callback.__name__})"
         name = ""
         for rs in self.recipe_steps:
             name += " "

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -722,6 +722,12 @@ class RunManager:
         if "extrande" in self.kmc_algorithm:
             kmc = partial(kmc, tau_scale=self.config.tau_scale)
         self.kmcresult = kmc(self.recipe_collection, logger=logger)
+        if type(self.kmcresult.recipe) == Callable:
+            if self.kmcresult.pos is None:
+                m = f"KMC algorithm {self.kmc_algorithm} returned a recipe function but no position."
+                logger.error(m)
+                raise ValueError(m)
+            self.kmcresult.recipe = self.kmcresult.recipe(self.kmcresult.pos)
         recipe = self.kmcresult.recipe
 
         if self.config.save_recipes:

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -741,20 +741,17 @@ class RunManager:
                     "outfile": files.outputdir / "reaction_rates.svg",
                     "highlight_r": recipe,
                 }
-                if (self.kmcresult.time_start is not None) and (
-                    self.kmcresult.time_start != 0
-                ):
+                if self.kmcresult.time_start != 0:
                     kwargs["highlight_t"] = self.kmcresult.time_start
                 self.recipe_collection.plot(**kwargs)
         except Exception as e:
             logger.warning(f"Error occured during plotting:\n{e}")
 
-        if self.kmcresult.time_delta:
-            self.time += self.kmcresult.time_delta
+        self.time += self.kmcresult.time_delta
         logger.info("Done with Decide recipe.")
         if len(recipe.rates) == 0:
             logger.info("No reaction selected")
-        elif self.kmcresult.time_delta:
+        else:
             logger.info(
                 f"Overall time {self.time*1e-12:.4e} s, reaction occured after {self.kmcresult.time_delta*1e-12:.4e} s"
             )
@@ -787,12 +784,13 @@ class RunManager:
 
         # Set time to chosen 'time_start' of KMCResult
         ttime = self.kmcresult.time_start
+        time_index = self.kmcresult.time_start_index
         if isinstance(recipe.recipe_steps, list):
             recipe.recipe_steps = recipe.recipe_steps
         elif isinstance(recipe.recipe_steps, DeferredRecipeSteps):
-            recipe.recipe_steps = recipe.recipe_steps.callback(recipe.recipe_steps.key)
+            recipe.recipe_steps = recipe.recipe_steps.callback(recipe.recipe_steps.key, time_index)
         else:
-            m = f"Recipe steps of {recipe} are not a list or a DeferredRecipeSteps object."
+            m = f"Recipe steps of {recipe} are neither a list nor a DeferredRecipeSteps object."
             logger.error(m)
             raise ValueError(m)
         if any([isinstance(step, Place) for step in recipe.recipe_steps]):

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -567,8 +567,7 @@ class RunManager:
         self,
         instance: str,
         files: TaskFiles,
-        continue_md: bool = False,
-        slow_growth=False,
+        continue_md: bool = False
     ) -> TaskFiles:
         """General MD simulation"""
         logger = files.logger
@@ -853,7 +852,7 @@ class RunManager:
                 task = Task(
                     self,
                     f=self._run_md,
-                    kwargs={"instance": instance, "slow_growth": True},
+                    kwargs={"instance": instance},
                     out=instance,
                 )
                 md_files = task()

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -800,6 +800,13 @@ class RunManager:
             # only first time of interval is valid for placement
             ttime = recipe.timespans[0][0]
 
+        # get vmd selection (after deferred steps are resolved)
+        vmd_selection = recipe.get_vmd_selection()
+        logger.info(f"VMD slection: {vmd_selection}")
+
+        # truncate simulation files to the chosen time
+        m = f"Truncating simulation files to time {ttime} ps"
+        logger.info(m)
         truncate_sim_files(files=files, time=ttime)
 
         top_initial = deepcopy(self.top)

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -24,7 +24,7 @@ from typing import Callable, Optional
 from kimmdy.config import Config
 from kimmdy.constants import MARK_DONE, MARK_FAILED, MARK_STARTED, MARKERS
 from kimmdy.coordinates import break_bond_plumed, merge_top_slow_growth, place_atom
-from kimmdy.kmc import KMCRejection, KMCResult, extrande, extrande_mod, frm, rf_kmc
+from kimmdy.kmc import KMCRejection, KMCResult, extrande, extrande_mod, frm, rf_kmc, total_index_to_index_within_plugin
 from kimmdy.parsing import read_top, write_json, write_time_marker, write_top
 from kimmdy.plugins import (
     BasicParameterizer,
@@ -830,7 +830,7 @@ class RunManager:
         # get vmd selection (after deferred steps are resolved)
         vmd_selection = recipe.get_vmd_selection()
         logger.info(f"VMD selection: {vmd_selection}")
-        with open(files.outputdir / "vmd_selection.txt") as f:
+        with open(files.outputdir / "vmd_selection.txt", 'w') as f:
             f.write(vmd_selection)
 
         # truncate simulation files to the chosen time

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -32,7 +32,15 @@ from kimmdy.plugins import (
     parameterization_plugins,
     reaction_plugins,
 )
-from kimmdy.recipe import Bind, Break, CustomTopMod, DeferredRecipeSteps, Place, RecipeCollection, Relax
+from kimmdy.recipe import (
+    Bind,
+    Break,
+    CustomTopMod,
+    DeferredRecipeSteps,
+    Place,
+    RecipeCollection,
+    Relax,
+)
 from kimmdy.tasks import Task, TaskFiles, get_plumed_out
 from kimmdy.topology.topology import Topology
 from kimmdy.topology.utils import get_is_reactive_predicate_from_config_f

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -823,7 +823,6 @@ class RunManager:
         recipe = self.kmcresult.recipe
         logger.info(f"Start Recipe in KIMMDY iteration {self.iteration}")
         logger.info(f"Recipe: {recipe.get_recipe_name()}")
-        logger.debug(f"Performing recipe steps:\n{pformat(recipe.recipe_steps)}")
 
         # Set time to chosen 'time_start' of KMCResult
         ttime = self.kmcresult.time_start

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -783,19 +783,19 @@ class RunManager:
         recipe = self.kmcresult.recipe
         logger.info(f"Start Recipe in KIMMDY iteration {self.iteration}")
         logger.info(f"Recipe: {recipe.get_recipe_name()}")
-        logger.debug(f"Performing recipe steps:\n{pformat(recipe.steps)}")
+        logger.debug(f"Performing recipe steps:\n{pformat(recipe.recipe_steps)}")
 
         # Set time to chosen 'time_start' of KMCResult
         ttime = self.kmcresult.time_start
-        if isinstance(recipe.steps, list):
-            recipe.steps = recipe.steps
-        elif isinstance(recipe.steps, DeferredRecipeSteps):
-            recipe.steps = recipe.steps.callback(recipe.steps.key)
+        if isinstance(recipe.recipe_steps, list):
+            recipe.recipe_steps = recipe.recipe_steps
+        elif isinstance(recipe.recipe_steps, DeferredRecipeSteps):
+            recipe.recipe_steps = recipe.recipe_steps.callback(recipe.recipe_steps.key)
         else:
             m = f"Recipe steps of {recipe} are not a list or a DeferredRecipeSteps object."
             logger.error(m)
             raise ValueError(m)
-        if any([isinstance(step, Place) for step in recipe.steps]):
+        if any([isinstance(step, Place) for step in recipe.recipe_steps]):
             # only first time of interval is valid for placement
             ttime = recipe.timespans[0][0]
 
@@ -803,7 +803,7 @@ class RunManager:
 
         top_initial = deepcopy(self.top)
         focus_nrs = set()
-        for step in recipe.steps:
+        for step in recipe.recipe_steps:
             if isinstance(step, Break):
                 self.top.break_bond((step.atom_id_1, step.atom_id_2))
                 focus_nrs.update([step.atom_id_1, step.atom_id_2])
@@ -861,7 +861,7 @@ class RunManager:
             elif isinstance(step, CustomTopMod):
                 step.f(self.top)
 
-        self.top.update_partial_charges(recipe.steps)
+        self.top.update_partial_charges(recipe.recipe_steps)
         self.top.update_parameters(focus_nrs)
 
         write_top(self.top.to_dict(), files.outputdir / self.config.top.name)

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -842,7 +842,9 @@ class RunManager:
             recipe.recipe_steps = recipe.recipe_steps.callback(
                 recipe.recipe_steps.key, plugin_time_index
             )
-            logger.info(f"Got {len(recipe.recipe_steps)} steps: {recipe.recipe_steps}")
+            logger.info(
+                f"Got {len(recipe.recipe_steps)} in recipe {recipe.get_recipe_name()}"
+            )
         else:
             m = f"Recipe steps of {recipe} are neither a list nor a DeferredRecipeSteps object."
             logger.error(m)

--- a/src/kimmdy/tasks.py
+++ b/src/kimmdy/tasks.py
@@ -57,7 +57,7 @@ class TaskFiles:
     >>>     def get_latest(self, s):
     >>>         return f"latest {s}"
     >>> runmng = run()
-    >>> files = TaskFiles(runmng)
+    >>> files = TaskFiles(runmng.get_latest)
     >>> files.input
     >>> files.input["top"]
     {'top': 'latest top'}

--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -1048,17 +1048,11 @@ class Topology:
                         continue
                     residue_bond_spec = residuetype.bonds.get(
                         bondtype,
-                        residuetype.bonds.get(
-                            (bondtype[-1], bondtype[-2])
-                        ),
+                        residuetype.bonds.get((bondtype[-1], bondtype[-2])),
                     )
                     if residue_bond_spec:
-                        atom1.charge = (
-                            residuetype.atoms[atom1.atom].charge
-                        )
-                        atom2.charge = (
-                            residuetype.atoms[atom2.atom].charge
-                        )
+                        atom1.charge = residuetype.atoms[atom1.atom].charge
+                        atom2.charge = residuetype.atoms[atom2.atom].charge
                     else:
                         logger.warning(
                             f"New bond defined in {step} but can't be found in residuetypes definition. Not changing the partial charges!"

--- a/src/kimmdy/topology/topology.py
+++ b/src/kimmdy/topology/topology.py
@@ -1461,10 +1461,12 @@ class Topology:
             for exclusion_key in reactive_moleculetype.exclusions.keys():
                 if ai in exclusion_key:
                     to_delete.append(exclusion_key)
+
             if len(to_delete) > 0:
                 logger.info(f"Removing exclusions {to_delete}")
             for key in to_delete:
                 reactive_moleculetype.exclusions.pop(key)
             settles = reactive_moleculetype.settles.get(ai)
             if settles is not None:
+                logger.info(f"Removing settles {ai}")
                 reactive_moleculetype.settles.pop(ai)

--- a/src/kimmdy/utils.py
+++ b/src/kimmdy/utils.py
@@ -31,8 +31,10 @@ The line number - 2 (for the title and the number of atoms) is always
 the correct the atom id.
 """
 
+
 def flatten_recipe_collections(d: dict[str, RecipeCollection]) -> RecipeCollection:
     return RecipeCollection(recipes=[x for v in d.values() for x in v.recipes])
+
 
 def field_or_none(l: list[str], i) -> Optional[str]:
     try:

--- a/src/kimmdy/utils.py
+++ b/src/kimmdy/utils.py
@@ -364,7 +364,7 @@ def check_gmx_version(config):
                         "'plumed', aborting due to apparent lack of PLUMED patch."
                         f"Version is: {version}"
                     )
-                    config._logmessages["error"].append(m)
+                    config._logmessages["errors"].append(m)
                     if not config.dryrun:
                         raise SystemError(m)
     if hasattr(config, "changer") and hasattr(config.changer, "coordinates"):

--- a/src/kimmdy/utils.py
+++ b/src/kimmdy/utils.py
@@ -8,9 +8,11 @@ import logging
 import re
 import subprocess as sp
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Iterable, Optional, Union
 
 import numpy as np
+
+from kimmdy.recipe import RecipeCollection
 
 if TYPE_CHECKING:
     from kimmdy.parsing import Plumed_dict
@@ -29,6 +31,8 @@ The line number - 2 (for the title and the number of atoms) is always
 the correct the atom id.
 """
 
+def flatten_recipe_collections(d: dict[str, RecipeCollection]) -> RecipeCollection:
+    return RecipeCollection(recipes=[x for v in d.values() for x in v.recipes])
 
 def field_or_none(l: list[str], i) -> Optional[str]:
     try:

--- a/src/kimmdy/utils.py
+++ b/src/kimmdy/utils.py
@@ -372,10 +372,7 @@ def check_gmx_version(config):
             m = "Note: slow growth of pairs is only supported by >= gromacs 2023.2. To disable morphing pairs in config: md.changer.coordinates.slow_growth_pairs = false"
             config._logmessages["debugs"].append(f"Gromacs version: {version}")
             config._logmessages["errors"].append(m)
-            print(version)
-            # version = "GROMACS version:     2024.2-plumed_2.10.0_dev"
             major_minor = re.match(r".*(\d{4})\.(\d+).*", version)
-            print(major_minor)
             if major_minor is not None:
                 year = int(major_minor.group(1))
                 minor = int(major_minor.group(2))

--- a/tests/test_kmc.py
+++ b/tests/test_kmc.py
@@ -96,6 +96,7 @@ def test_extrande_mod_calculation(recipe_collection, reference_extrande_KMC):
     # first random numbers are array([0.51182162, 0.9504637])
     KMC_dict = extrande_mod(recipe_collection, 1.0, rng=rng)
     assert KMC_dict.recipe == reference_extrande_KMC.recipe
+    assert KMC_dict.time_start is not None
     assert (
         abs(KMC_dict.time_start - 2.4632908726674225) < 1e-9
     )  # single result different, same distribution?

--- a/tests/test_kmc.py
+++ b/tests/test_kmc.py
@@ -3,7 +3,15 @@ import pytest
 import numpy as np
 from numpy.random import default_rng
 from kimmdy.recipe import Recipe, RecipeCollection, Break, Bind
-from kimmdy.kmc import KMCRejection, rf_kmc, frm, extrande, extrande_mod, KMCResult, total_index_to_index_within_plugin
+from kimmdy.kmc import (
+    KMCRejection,
+    rf_kmc,
+    frm,
+    extrande,
+    extrande_mod,
+    KMCResult,
+    total_index_to_index_within_plugin,
+)
 
 
 @pytest.fixture
@@ -30,7 +38,7 @@ def reference_KMC() -> KMCResult:
         time_delta=0.04032167624965666,
         reaction_probability=[0.0, 0.72, 0.54, 0.0],
         time_start=0,
-        time_start_index=0
+        time_start_index=0,
     )
 
 
@@ -139,25 +147,28 @@ def test_frm_no_event(recipe_collection):
 
 def test_compare_extrande_extrande_mod(recipe_collection):
     rng = default_rng(1)
-    extrande_list = [
-        extrande(recipe_collection, 1.0, rng=rng)
-        for _ in range(2000)
-    ]
+    extrande_list = [extrande(recipe_collection, 1.0, rng=rng) for _ in range(2000)]
     extrande_mod_list = [
-        extrande_mod(recipe_collection, 1.0, rng=rng)
-        for _ in range(2000)
+        extrande_mod(recipe_collection, 1.0, rng=rng) for _ in range(2000)
     ]
     ext_ts = np.array([r.time_start for r in extrande_list if isinstance(r, KMCResult)])
-    extmod_ts = np.array([r.time_start for r in extrande_mod_list if isinstance(r, KMCResult)])
+    extmod_ts = np.array(
+        [r.time_start for r in extrande_mod_list if isinstance(r, KMCResult)]
+    )
     mask = np.nonzero(ext_ts != np.array(None))[0]
     mmask = np.nonzero(extmod_ts != np.array(None))[0]
 
     assert abs(ext_ts[mask].mean() - extmod_ts[mmask].mean()) < 0.1
 
-    ext_rs = np.concatenate([r.recipe.rates for r in extrande_list if isinstance(r, KMCResult)])
-    extmod_rs = np.concatenate([r.recipe.rates for r in extrande_mod_list if isinstance(r, KMCResult)])
+    ext_rs = np.concatenate(
+        [r.recipe.rates for r in extrande_list if isinstance(r, KMCResult)]
+    )
+    extmod_rs = np.concatenate(
+        [r.recipe.rates for r in extrande_mod_list if isinstance(r, KMCResult)]
+    )
 
     assert abs(ext_rs.mean() - extmod_rs.mean()) < 0.002
+
 
 def test_total_index_to_index_within_plugin():
     ns = [3, 2, 4, 1]
@@ -167,6 +178,3 @@ def test_total_index_to_index_within_plugin():
     assert total_index_to_index_within_plugin(3, ns) == 0
     assert total_index_to_index_within_plugin(4, ns) == 1
     assert total_index_to_index_within_plugin(5, ns) == 0
-
-
-

--- a/tests/test_kmc.py
+++ b/tests/test_kmc.py
@@ -3,7 +3,7 @@ import pytest
 import numpy as np
 from numpy.random import default_rng
 from kimmdy.recipe import Recipe, RecipeCollection, Break, Bind
-from kimmdy.kmc import KMCRejection, rf_kmc, frm, extrande, extrande_mod, KMCResult
+from kimmdy.kmc import KMCRejection, rf_kmc, frm, extrande, extrande_mod, KMCResult, total_index_to_index_within_plugin
 
 
 @pytest.fixture
@@ -139,14 +139,12 @@ def test_frm_no_event(recipe_collection):
 
 def test_compare_extrande_extrande_mod(recipe_collection):
     rng = default_rng(1)
-    dummy_logger = logging.Logger("Dummy")
-    dummy_logger.setLevel(logging.DEBUG)
     extrande_list = [
-        extrande(recipe_collection, 1.0, rng=rng, logger=dummy_logger)
+        extrande(recipe_collection, 1.0, rng=rng)
         for _ in range(2000)
     ]
     extrande_mod_list = [
-        extrande_mod(recipe_collection, 1.0, rng=rng, logger=dummy_logger)
+        extrande_mod(recipe_collection, 1.0, rng=rng)
         for _ in range(2000)
     ]
     ext_ts = np.array([r.time_start for r in extrande_list if isinstance(r, KMCResult)])
@@ -160,3 +158,15 @@ def test_compare_extrande_extrande_mod(recipe_collection):
     extmod_rs = np.concatenate([r.recipe.rates for r in extrande_mod_list if isinstance(r, KMCResult)])
 
     assert abs(ext_rs.mean() - extmod_rs.mean()) < 0.002
+
+def test_total_index_to_index_within_plugin():
+    ns = [3, 2, 4, 1]
+    assert total_index_to_index_within_plugin(0, ns) == 0
+    assert total_index_to_index_within_plugin(1, ns) == 1
+    assert total_index_to_index_within_plugin(2, ns) == 2
+    assert total_index_to_index_within_plugin(3, ns) == 0
+    assert total_index_to_index_within_plugin(4, ns) == 1
+    assert total_index_to_index_within_plugin(5, ns) == 0
+
+
+

--- a/tests/test_kmc.py
+++ b/tests/test_kmc.py
@@ -69,22 +69,21 @@ def compare_to_ref(result: KMCAccept, reference: KMCAccept):
 
 def test_rf_kmc_empty():
     kmc = rf_kmc(RecipeCollection([]))
-    assert isinstance(kmc, KMCReject)
+    assert isinstance(kmc, KMCError)
 
 
 def test_frm_empty():
     kmc = frm(RecipeCollection([]))
-    assert isinstance(kmc, KMCReject)
-
+    assert isinstance(kmc, KMCError)
 
 def test_extrande_empty():
     kmc = extrande(RecipeCollection([]), 1.0)
-    assert isinstance(kmc, KMCReject)
+    assert isinstance(kmc, KMCError)
 
 
 def test_extrande_mod_empty():
     kmc = extrande_mod(RecipeCollection([]), 1.0)
-    assert isinstance(kmc, KMCReject)
+    assert isinstance(kmc, KMCError)
 
 
 def test_rf_kmc_unlike_ref(reference_KMC):
@@ -143,7 +142,7 @@ def test_frm_no_event(recipe_collection):
     # first random numbers are array([0.51182162, 0.9504637 , 0.14415961, 0.94864945])
     new_recipes = recipe_collection.recipes[2:4]
     kmc = frm(RecipeCollection(new_recipes), rng=rng, MD_time=None)
-    assert isinstance(kmc, KMCReject)
+    assert isinstance(kmc, KMCError)
 
 
 def test_compare_extrande_extrande_mod(recipe_collection):

--- a/tests/test_kmc.py
+++ b/tests/test_kmc.py
@@ -76,6 +76,7 @@ def test_frm_empty():
     kmc = frm(RecipeCollection([]))
     assert isinstance(kmc, KMCError)
 
+
 def test_extrande_empty():
     kmc = extrande(RecipeCollection([]), 1.0)
     assert isinstance(kmc, KMCError)

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -247,6 +247,11 @@ def test_recipe_steps_from_string_with_deferred():
     assert isinstance(steps, recipe.DeferredRecipeSteps)
     assert steps.key == '1'
 
+    def some_function(key):
+        _ = key
+        return []
+    assert steps == recipe.DeferredRecipeSteps('1', some_function)
+
 def test_recipe_collection_from_csv_picked(
     tmp_path: Path, recipe_collection: recipe.RecipeCollection
 ):

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -235,11 +235,17 @@ def test_recipe_steps_from_string():
         return x
 
     steps = recipe.recipe_steps_from_str(s)
+    assert isinstance(steps, list)
     assert len(steps) == 8
     assert steps[0] == recipe.Break(1710, 1712)
     assert isinstance(steps[7], recipe.CustomTopMod)
     assert steps[7].__almost_eq__(recipe.CustomTopMod(f=id))
 
+def test_recipe_steps_from_string_with_deferred():
+    s = "<1,some_function>"
+    steps = recipe.recipe_steps_from_str(s)
+    assert isinstance(steps, recipe.DeferredRecipeSteps)
+    assert steps.key == '1'
 
 def test_recipe_collection_from_csv_picked(
     tmp_path: Path, recipe_collection: recipe.RecipeCollection

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -248,11 +248,12 @@ def test_recipe_steps_from_string_with_deferred():
     assert isinstance(steps, recipe.DeferredRecipeSteps)
     assert steps.key == "1"
 
-    def some_function(key):
+    def some_function(key, i):
         _ = key
+        _ = i
         return []
 
-    assert steps == recipe.DeferredRecipeSteps("1", some_function)
+    assert steps == recipe.DeferredRecipeSteps(key="1", callback=some_function)
 
 
 def test_recipe_collection_from_csv_picked(

--- a/tests/test_recipe.py
+++ b/tests/test_recipe.py
@@ -241,16 +241,19 @@ def test_recipe_steps_from_string():
     assert isinstance(steps[7], recipe.CustomTopMod)
     assert steps[7].__almost_eq__(recipe.CustomTopMod(f=id))
 
+
 def test_recipe_steps_from_string_with_deferred():
     s = "<1,some_function>"
     steps = recipe.recipe_steps_from_str(s)
     assert isinstance(steps, recipe.DeferredRecipeSteps)
-    assert steps.key == '1'
+    assert steps.key == "1"
 
     def some_function(key):
         _ = key
         return []
-    assert steps == recipe.DeferredRecipeSteps('1', some_function)
+
+    assert steps == recipe.DeferredRecipeSteps("1", some_function)
+
 
 def test_recipe_collection_from_csv_picked(
     tmp_path: Path, recipe_collection: recipe.RecipeCollection


### PR DESCRIPTION
## Feature

The `recipe_steps` of a `Recipe` can now be a `DeferredRecipeSteps` object (or like normal a list or `RecipeSteps`s).
An instance of `DeferredRecipeSteps` contains a `callback` and a `key` to identify internally what steps to return back when asked. In addition to the key the callback is given the index of the chosen time/frame by the KMC algorithm of KIMMDY. This index is mapped back to the internal index of the plugin from the total number of recipes.
`DeferredRecipeSteps` is generic over the type of `key`.

An example implementation that makes use of this feature is available for hydrolysis: https://github.com/graeter-group/kimmdy-hydrolysis-naive/, which uses SASA as a proxy for reaction probability and only chooses a specific water molecule for the attack once a reactive peptide bond and time has been choosen by KMC.

## Related discussion

`kmc` gained the responsibility of returning the time_index in addition to the chosen reaction time, which is why I looked closer at it.
The `KMCResults` class was doing multiple jobs by always being returned from `kmc`, but having various empty or `None` parameters, which meant that those where declared as `Optional`. However, for a kmc that chose a result those are not actually optional. By introducing an additional `KMCRejection` type we move validation and checking up the chain and save null-checks in various places.

However, I want to use this opportunity to check back if these are actually the only two valid types of results or if there is also a third option that needs special handling.

## Small things

- slow growth settings matching the current gromacs version are now checked during config validation
- fix escape sequence in jobscript template
- after the selection of a reaction a VMD selection string for the involved atoms is logged and written to a file called vmd_selection.txt in the directory of the `apply_recipe` task, which is useful for debugging.
- the `kmc` module now uses a module-defined logger like the other modules instead of passing the logger manually

