### PR TITLE
fix: copy gro to setup

### DIFF
--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -444,7 +444,7 @@ class RunManager:
         # copy input files that are potentially modified
         # to the setup task directory
         # by applying a recipe (e.g. by trunkate_sim_files)
-        for f in ["xtc", "tpr", "trr", "plumed"]:
+        for f in ["xtc", "tpr", "trr", "plumed", "gro"]:
             if hasattr(self.config, f):
                 if path := self.latest_files.get(f):
                     logger.debug(f"Copying {path} to {files.outputdir}")


### PR DESCRIPTION
Necessary if starting from existing traj as it might be truncated, leading to a new gro of the last frame.