### PR TITLE
fix: link residuetypedat

### DIFF
--- a/src/kimmdy/kimmdy-yaml-schema.json
+++ b/src/kimmdy/kimmdy-yaml-schema.json
@@ -215,12 +215,6 @@
       "pytype": "Path",
       "default": "*.ff"
     },
-    "residuetypesdat": {
-      "title": "residuetypesdat",
-      "description": "GROMACS dat file that matches group names to residuetypes. Will be linked everywhere the forecfield will be.",
-      "type": "string",
-      "pytype": "Path"
-    },
     "residuetypes": {
       "title": "residuetypes",
       "description": "GROMACS rtp file that contains residuetypes. Looks for `aminoacids.rtp` it not set. KIMMDY will first look in the current working directory and then relative to the forecfield directory.",

--- a/src/kimmdy/kimmdy-yaml-schema.json
+++ b/src/kimmdy/kimmdy-yaml-schema.json
@@ -215,6 +215,12 @@
       "pytype": "Path",
       "default": "*.ff"
     },
+    "residuetypesdat": {
+      "title": "residuetypesdat",
+      "description": "GROMACS dat file that matches group names to residuetypes. Will be linked everywhere the forecfield will be.",
+      "type": "string",
+      "pytype": "Path"
+    },
     "residuetypes": {
       "title": "residuetypes",
       "description": "GROMACS rtp file that contains residuetypes. Looks for `aminoacids.rtp` it not set. KIMMDY will first look in the current working directory and then relative to the forecfield directory.",

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -249,7 +249,8 @@ class RunManager:
         logger.info("Start run")
         self.start_time = time.time()
 
-        if getattr(self.config.restart, "run_directory", None):
+        if restart_dir := getattr(self.config.restart, "run_directory", None):
+            logger.info(f"Restarting from: {restart_dir}")
             self._restart_from_rundir()
 
         while (
@@ -447,7 +448,9 @@ class RunManager:
             if hasattr(self.config, f):
                 if path := self.latest_files.get(f):
                     logger.debug(f"Copying {path} to {files.outputdir}")
-                    shutil.copy(path, files.outputdir / path.name)
+                    shutil.copy(
+                        path, files.outputdir / path.name, follow_symlinks=False
+                    )
                     files.output[f] = files.outputdir / path.name
 
         return files

--- a/src/kimmdy/tasks.py
+++ b/src/kimmdy/tasks.py
@@ -111,8 +111,6 @@ def create_task_directory(runmng, postfix: str) -> TaskFiles:
                 runmng.config.ff / "residuetypes.dat"
             )
 
-    if resdat := getattr(runmng.config, "residuetypesdat", None):
-        (files.outputdir / resdat.name).symlink_to(resdat)
     return files
 
 

--- a/src/kimmdy/tasks.py
+++ b/src/kimmdy/tasks.py
@@ -106,6 +106,9 @@ def create_task_directory(runmng, postfix: str) -> TaskFiles:
     if runmng.config.ff is not None:
         if not (files.outputdir / runmng.config.ff.name).exists():
             (files.outputdir / runmng.config.ff.name).symlink_to(runmng.config.ff)
+        if not (files.outputdir / "residuetypes.dat").exists():
+            (files.outputdir / "residuetypes.dat").symlink_to(runmng.config.ff / "residuetypes.dat")
+
     if resdat := getattr(runmng.config, "residuetypesdat", None):
         (files.outputdir / resdat.name).symlink_to(resdat)
     return files

--- a/src/kimmdy/tasks.py
+++ b/src/kimmdy/tasks.py
@@ -107,7 +107,9 @@ def create_task_directory(runmng, postfix: str) -> TaskFiles:
         if not (files.outputdir / runmng.config.ff.name).exists():
             (files.outputdir / runmng.config.ff.name).symlink_to(runmng.config.ff)
         if not (files.outputdir / "residuetypes.dat").exists():
-            (files.outputdir / "residuetypes.dat").symlink_to(runmng.config.ff / "residuetypes.dat")
+            (files.outputdir / "residuetypes.dat").symlink_to(
+                runmng.config.ff / "residuetypes.dat"
+            )
 
     if resdat := getattr(runmng.config, "residuetypesdat", None):
         (files.outputdir / resdat.name).symlink_to(resdat)

--- a/src/kimmdy/tasks.py
+++ b/src/kimmdy/tasks.py
@@ -106,7 +106,8 @@ def create_task_directory(runmng, postfix: str) -> TaskFiles:
     if runmng.config.ff is not None:
         if not (files.outputdir / runmng.config.ff.name).exists():
             (files.outputdir / runmng.config.ff.name).symlink_to(runmng.config.ff)
-
+    if resdat := getattr(runmng.config, "residuetypesdat", None):
+        (files.outputdir / resdat.name).symlink_to(resdat)
     return files
 
 


### PR DESCRIPTION
Gromacs needs the residuetype.dat file in the run dir to properly assign residues to groups like `Protein` used in mdp file.