### PR TITLE
feat: multi rfkmc

### DIFF
--- a/src/kimmdy/kimmdy-yaml-schema.json
+++ b/src/kimmdy/kimmdy-yaml-schema.json
@@ -131,9 +131,17 @@
         "rfkmc",
         "frm",
         "extrande",
-        "extrande_mod"
+        "extrande_mod",
+        "multi_rfkmc"
       ],
       "default": ""
+    },
+    "multi_kmc": {
+      "title": "multi_kmc",
+      "description": "Number of reactions to be executed in one step by a `multi` variant of a KMC algorithm.",
+      "type": "integer",
+      "pytype": "int",
+      "default": 1
     },
     "tau_scale": {
       "title": "tau_scale",

--- a/src/kimmdy/runmanager.py
+++ b/src/kimmdy/runmanager.py
@@ -33,6 +33,7 @@ from kimmdy.kmc import (
     extrande_mod,
     frm,
     rf_kmc,
+    multi_rfkmc,
     total_index_to_index_within_plugin,
 )
 from kimmdy.parsing import read_top, write_json, write_time_marker, write_top
@@ -226,6 +227,7 @@ class RunManager:
             "rfkmc": rf_kmc,
             "frm": frm,
             "extrande_mod": extrande_mod,
+            "multi_rfkmc": multi_rfkmc,
         }
 
         self.task_mapping = {
@@ -767,6 +769,12 @@ class RunManager:
                 collection.aggregate_reactions()
         if "extrande" in self.kmc_algorithm:
             kmc = partial(kmc, tau_scale=self.config.tau_scale)
+        elif "multi" in self.kmc_algorithm:
+            logger.debug(
+                f"Setting {self.kmc_algorithm} up to pick "
+                f"{self.config.multi_kmc} reactions."
+            )
+            kmc = partial(kmc, n=self.config.multi_kmc)
 
         self.kmcresult = kmc(flatten_recipe_collections(self.recipe_collections))
         if not isinstance(self.kmcresult, KMCAccept):

--- a/src/kimmdy/utils.py
+++ b/src/kimmdy/utils.py
@@ -368,7 +368,10 @@ def check_gmx_version(config):
                     if not config.dryrun:
                         raise SystemError(m)
     if hasattr(config, "changer") and hasattr(config.changer, "coordinates"):
-        if config.changer.coordinates.slow_growth_pairs and config.changer.coordinates.slow_growth:
+        if (
+            config.changer.coordinates.slow_growth_pairs
+            and config.changer.coordinates.slow_growth
+        ):
             m = "Note: slow growth of pairs is only supported by >= gromacs 2023.2. To disable morphing pairs in config: md.changer.coordinates.slow_growth_pairs = false"
             config._logmessages["debugs"].append(f"Gromacs version: {version}")
             config._logmessages["errors"].append(m)

--- a/tests/test_kmc.py
+++ b/tests/test_kmc.py
@@ -11,6 +11,7 @@ from kimmdy.kmc import (
     extrande_mod,
     KMCAccept,
     total_index_to_index_within_plugin,
+    multi_rfkmc,
 )
 
 
@@ -38,6 +39,21 @@ def reference_KMC() -> KMCAccept:
         time_delta=0.04032167624965666,
         reaction_probability=[0.0, 0.72, 0.54, 0.0],
         time_start=0,
+        time_start_index=0,
+    )
+
+
+@pytest.fixture
+def reference_multi2_KMC() -> KMCAccept:
+    return KMCAccept(
+        recipe=Recipe(
+            recipe_steps=[Bind(2, 3), Break(3, 4), Bind(4, 5)],
+            rates=[0.12, 0.0, 0.15, 0.06],
+            timespans=[(0.0, 6.0), (6.0, 10.0), (2.0, 4.0), (4.0, 8.0)],
+        ),
+        time_delta=0.09762211196506274,
+        reaction_probability=[0.0, 0.72, 0.54, 0.0],
+        time_start=6.0,
         time_start_index=0,
     )
 
@@ -126,6 +142,26 @@ def test_rf_kmc_calculation(recipe_collection, reference_KMC):
     assert isinstance(kmc, KMCAccept)
     compare_to_ref(kmc, reference_KMC)
     assert abs(kmc.time_delta - reference_KMC.time_delta) < 1e-9
+
+
+def test_multi_rf_kmc_calculation(recipe_collection, reference_KMC):
+    # n=1 should be identical to standard rfkmc
+    rng = default_rng(1)
+    # first random numbers are array([0.51182162, 0.9504637])
+    kmc = multi_rfkmc(recipe_collection, n=1, rng=rng)
+    assert isinstance(kmc, KMCAccept)
+    compare_to_ref(kmc, reference_KMC)
+    assert abs(kmc.time_delta - reference_KMC.time_delta) < 1e-9
+
+
+def test_multi2_rf_kmc_calculation(recipe_collection, reference_multi2_KMC):
+    rng = default_rng(1)
+    # first random numbers are array([0.51182162, 0.9504637])
+    kmc = multi_rfkmc(recipe_collection, n=2, rng=rng)
+
+    assert isinstance(kmc, KMCAccept)
+    compare_to_ref(kmc, reference_multi2_KMC)
+    assert abs(kmc.time_delta - reference_multi2_KMC.time_delta) < 1e-9
 
 
 def test_frm_calculation(recipe_collection, reference_KMC):


### PR DESCRIPTION
Execute multiple reactions at a time.  
Multiple ReactionResults are sampled and then combined into one. The same recipe can't be sampled again, but there is no exclusion of nearby reactions.  
`time_delta` is defined by the max of all selected recipes.