### PR TITLE
fix(testing): TypeError raised during test_parser_invertible fixes #557

### DIFF
--- a/src/kimmdy/parsing.py
+++ b/src/kimmdy/parsing.py
@@ -324,6 +324,12 @@ def read_top(
                         parent_section = f"{parent_section}_{moleculetype_name}"
                     d[parent_section] = empty_section(condition)
                     d[parent_section]["subsections"] = {}
+                    
+                #specific case that can occur during testing
+                elif parent_section in d.keys(): 
+                    parent_section = parent_section + "_repeat"
+                    d[parent_section] = empty_section(condition)
+                    d[parent_section]["subsections"] = {}
             else:
                 if parent_section is not None:
                     # add empty section as subsection

--- a/src/kimmdy/parsing.py
+++ b/src/kimmdy/parsing.py
@@ -324,9 +324,9 @@ def read_top(
                         parent_section = f"{parent_section}_{moleculetype_name}"
                     d[parent_section] = empty_section(condition)
                     d[parent_section]["subsections"] = {}
-                    
-                #specific case that can occur during testing
-                elif parent_section in d.keys(): 
+
+                # specific case that can occur during testing
+                elif parent_section in d.keys():
                     parent_section = parent_section + "_repeat"
                     d[parent_section] = empty_section(condition)
                     d[parent_section]["subsections"] = {}

--- a/src/kimmdy/parsing.py
+++ b/src/kimmdy/parsing.py
@@ -324,12 +324,6 @@ def read_top(
                         parent_section = f"{parent_section}_{moleculetype_name}"
                     d[parent_section] = empty_section(condition)
                     d[parent_section]["subsections"] = {}
-
-                # specific case that can occur during testing
-                elif parent_section in d.keys():
-                    parent_section = parent_section + "_repeat"
-                    d[parent_section] = empty_section(condition)
-                    d[parent_section]["subsections"] = {}
             else:
                 if parent_section is not None:
                     # add empty section as subsection

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -84,7 +84,7 @@ allowed_text = st.text(
     # a list of lists that correspond to a sections of a top file
     sections=st.lists(
         st.lists(
-            allowed_text.filter(lambda x: x not in ["ffdir","define"]),
+            allowed_text.filter(lambda x: x not in ["ffdir", "define"]),
             min_size=2,
             max_size=5,
         ),

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -3,7 +3,7 @@ import string
 from pathlib import Path
 
 import pytest
-from hypothesis import HealthCheck, given, settings
+from hypothesis import HealthCheck, given, settings, assume
 from hypothesis import strategies as st
 
 from kimmdy import parsing
@@ -84,7 +84,7 @@ allowed_text = st.text(
     # a list of lists that correspond to a sections of a top file
     sections=st.lists(
         st.lists(
-            allowed_text,
+            allowed_text.filter(lambda x: x not in ["ffdir","define"]),
             min_size=2,
             max_size=5,
         ),

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -3,7 +3,7 @@ import string
 from pathlib import Path
 
 import pytest
-from hypothesis import HealthCheck, given, settings, assume
+from hypothesis import HealthCheck, given, settings
 from hypothesis import strategies as st
 
 from kimmdy import parsing


### PR DESCRIPTION
During `test_parser_invertible`, there is a rare chance that `allowed_text` generates `ffdir` or `define` as a section title within the toplogy file that is generated for the test. When this occurs, `read_top` throws a TypeError as the dictionary defined within the function, `d`, already has `ffdir` and `define` as keys. This results in the function skipping generating the empty subsections. When the subsequent content tries to be appeneded, the TypeError is thrown as d["ffdir"] is not a dictionary.

To fix this, I have made use of Hypothesis's `.filter` function, restricting the `allowed_text` values to exclude `ffdir` and `define` for `test_parser_invertible`.