### PR TITLE
fix: rm libs of previous python version during tox run

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
    clean
    py310
+   clean-310
    py311
    report
 
@@ -25,6 +26,12 @@ commands =
 deps = coverage
 skip_install = true
 commands = coverage erase
+
+[testenv:clean-310]
+deps = coverage
+skip_install = true
+allowlist_externals=rm
+commands = rm -r .tox/py310/lib
 
 [testenv:report]
 deps = coverage


### PR DESCRIPTION
This PR adds a clean-up step to tox, in which the libs of the previous py version get deleted to free up disk space.

fixes #561