### PR TITLE
test: fix parser invertable

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -84,7 +84,9 @@ allowed_text = st.text(
     # a list of lists that correspond to a sections of a top file
     sections=st.lists(
         st.lists(
-            allowed_text.filter(lambda x: x not in ["ffdir", "define"]),
+            allowed_text.filter(
+                lambda x: x not in ["ffdir", "define", "moleculetype_"]
+            ),
             min_size=2,
             max_size=5,
         ),


### PR DESCRIPTION
`moleculetype_` would break the invertibility.