### PR TITLE
fix: don't resolve symlinks

### DIFF
--- a/src/kimmdy/config.py
+++ b/src/kimmdy/config.py
@@ -332,7 +332,7 @@ class Config:
                 out_end = name[-1]
                 if out_end.isdigit():
                     self.out = self.out.with_name(
-                        f"{'_'.join(name[:-1])}_{int(out_end)+1:03}"
+                        f"{'_'.join(name[:-1])}_{int(out_end) + 1:03}"
                     )
                 else:
                     self.out = self.out.with_name(self.out.name + "_001")
@@ -472,7 +472,7 @@ class Config:
                     and not path.is_absolute()
                 ):
                     path = cwd / path
-                path = path.resolve()
+                path = path.absolute()
                 self.__setattr__(name, path)
                 if (
                     not path.is_dir()

--- a/src/kimmdy/parsing.py
+++ b/src/kimmdy/parsing.py
@@ -47,7 +47,7 @@ def resolve_includes(
     ffdir:
         Path to the ff directory if one of the includes used a file from it.
     """
-    path = path.resolve()
+    path = path.absolute()
     dir = path.parent
     cwd = Path.cwd()
     if not dir.exists() or not path.exists():
@@ -71,7 +71,7 @@ def resolve_includes(
                     # test if the path is in the cwd, otherwise search in gmx ff dir
                     if not ffdir.exists() and gmx_builtin_ffs is not None:
                         ffdir = gmx_builtin_ffs / ffdir
-                    ffdir = ffdir.resolve()
+                    ffdir = ffdir.absolute()
                 ls_prime, _ = resolve_includes(include_path, gmx_builtin_ffs)
                 if not ls_prime and gmx_builtin_ffs is not None:
                     ls_prime, _ = resolve_includes(


### PR DESCRIPTION
If symlinks are resolved, gmx searches for the ff in the original dir, not next to the symlink, while producing unhelpful error messages. With this fix, the ff is resolved from the same place as kimmdy checks for it.

(`slow` tests run fine as well)
fixes #575